### PR TITLE
Update HALs and other dependencies, simplify examples where able

### DIFF
--- a/esp-ieee802154-examples/Cargo.lock
+++ b/esp-ieee802154-examples/Cargo.lock
@@ -49,9 +49,9 @@ checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "byte"
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -119,27 +119,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -162,25 +162,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.0"
+name = "embedded-io"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "658bbadc628dc286b9ae02f0cb0f5411c056eb7487b72f0083203f115de94060"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "esp-backtrace"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b151ef7db21143b1a3b7a378c16d97ae13d0a5e3cb9682ed1f11bba821cce42d"
+checksum = "4c7d3ecccb0df809cb6ca79b08f863271c0aa24f586df96272988a85d34dfa62"
 dependencies = [
  "esp-println",
 ]
 
 [[package]]
 name = "esp-hal-common"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9bb3220d63ba0ec4e9b1846edd47e8da3a884c6557b3ba7398494c56a93de35"
+checksum = "29b785e4195e1e1e6fae5b8c7fc44a1a71efa94e0b69527a38cce64815bfe7a6"
 dependencies = [
  "basic-toml",
  "bitfield",
@@ -189,12 +195,12 @@ dependencies = [
  "critical-section",
  "embedded-dma",
  "embedded-hal",
+ "embedded-io",
  "esp-hal-procmacros",
  "esp-riscv-rt",
  "esp32c6",
  "esp32h2",
  "fugit",
- "log",
  "nb 1.1.0",
  "paste",
  "riscv-atomic-emulation-trap",
@@ -205,16 +211,16 @@ dependencies = [
 
 [[package]]
 name = "esp-hal-procmacros"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "042d5a1ef0e01d6de045972779e4aced3a10e6170169a5cb2de7bef31802e28a"
+checksum = "d4cdf19581f9b0bb2b57b1549a2e639342825344b52f34048ddb29c46efa30de"
 dependencies = [
  "darling",
  "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -247,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "esp-println"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6a511d37dba5fb8f01bf5485bc619a1a1959e1aaf666a7597df8fe615a0816"
+checksum = "79b429ea925356d60c10d7214cf0e1777d9578c1287cd50aad09df3c22c4c2f1"
 dependencies = [
  "critical-section",
  "log",
@@ -257,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "esp-riscv-rt"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1008d28898f6dc8bab1c01f14826399b93f7e5f910c83062fc1d19eb5b5f28"
+checksum = "7639ac03e9fe4e6d5f1c0e90b95ce9478d487335f6684c22b3515e6dc3155d8f"
 dependencies = [
  "riscv",
  "riscv-rt-macros",
@@ -267,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "esp32c6"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17de7bcc3ec3966ccb60a271968125d471bee348da445a80b970efca1db8b4f"
+checksum = "b218d980ffb5eec9f60f94f1a1551c694683b31cb535770a2b9b9bbf3de14035"
 dependencies = [
  "critical-section",
  "vcell",
@@ -277,20 +283,18 @@ dependencies = [
 
 [[package]]
 name = "esp32c6-hal"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e3a6aa9d32a90bf6b673c046e8bb04a564c40ee4f367bb1d3df1fb45802c22"
+checksum = "12335dedcfa4ff0391e92432d1a305897343e86a50cbb09aaec914e773b780f5"
 dependencies = [
- "cfg-if",
- "embedded-hal",
  "esp-hal-common",
 ]
 
 [[package]]
 name = "esp32h2"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d26e14e0c9b47d073fec0894258195fd707abfef6bf702b08a62402bdeb540a"
+checksum = "4130d185ad505127b2f69b3e76fbb57e3798804b9fd8ffa93befed5c481da451"
 dependencies = [
  "critical-section",
  "vcell",
@@ -298,12 +302,10 @@ dependencies = [
 
 [[package]]
 name = "esp32h2-hal"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05039c4a20884e53ac3e6884b99c275de304284c4288cf40f97f0aaa581ed203"
+checksum = "f2af7ef9f671f1baccb0bb51ee4cd758bdf90e4c75ec22456a283a922b77f80d"
 dependencies = [
- "cfg-if",
- "embedded-hal",
  "esp-hal-common",
 ]
 
@@ -424,15 +426,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "nb"
@@ -497,18 +499,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -526,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "riscv-atomic-emulation-trap"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da39f4a5642a62e8e16bb438c37e6f90ea388ca0b7960fe875ea39887155d6ba"
+checksum = "7979127070e70f34c0ad6cc5a3a13f09af8dab1e9e154c396eb818f478504143"
 
 [[package]]
 name = "riscv-rt-macros"
@@ -552,40 +554,40 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.186"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5db24220c009de9bd45e69fb2938f4b6d2df856aa9304ce377b3180f83b7c1"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.186"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad697f7e0b65af4983a4ce8f56ed5b357e8d3c36651bf6a7e13639c17b8e670"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -628,7 +630,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -650,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -667,9 +669,9 @@ checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.11"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266f016b7f039eec8a1a80dfe6156b633d208b9fccca5e4db1d6775b0c4e34a7"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -684,9 +686,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "vcell"
@@ -708,9 +710,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "winnow"
-version = "0.4.7"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
+checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
 dependencies = [
  "memchr",
 ]

--- a/esp-ieee802154-examples/Cargo.toml
+++ b/esp-ieee802154-examples/Cargo.toml
@@ -5,14 +5,14 @@ edition = "2021"
 publish = false
 
 [dependencies]
-esp-backtrace  = { version = "0.7.0", features = ["panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace  = { version = "0.8.0", features = ["panic-handler", "exception-handler", "print-uart"] }
 esp-ieee802154 = { version = "0.1.0", path = "../esp-ieee802154" }
-esp-println    = { version = "0.5.0", features = ["log"] }
-esp32c6-hal    = { version = "0.4.0", optional = true }
-esp32h2-hal    = { version = "0.2.0", optional = true }
+esp-println    = { version = "0.6.0", features = ["log"] }
+esp32c6-hal    = { version = "0.5.0", optional = true }
+esp32h2-hal    = { version = "0.3.0", optional = true }
 heapless       = "0.7.16"
 ieee802154     = "0.6.1"
-log            = "0.4.18"
+log            = "0.4.20"
 
 [features]
 esp32c6 = ["esp32c6-hal", "esp-backtrace/esp32c6", "esp-ieee802154/esp32c6", "esp-println/esp32c6"]

--- a/esp-ieee802154-examples/examples/receive_all_frames.rs
+++ b/esp-ieee802154-examples/examples/receive_all_frames.rs
@@ -10,8 +10,6 @@ use esp_hal::{
     clock::{ClockControl, CpuClock},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_ieee802154::*;
 use esp_println::println;
@@ -23,29 +21,9 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     #[cfg(feature = "esp32c6")]
-    let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock160MHz).freeze();
+    let _clocks = ClockControl::configure(system.clock_control, CpuClock::Clock160MHz).freeze();
     #[cfg(feature = "esp32h2")]
-    let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock96MHz).freeze();
-
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::configure(system.clock_control, CpuClock::Clock96MHz).freeze();
 
     println!("Start");
 

--- a/esp-ieee802154-examples/examples/receive_frame.rs
+++ b/esp-ieee802154-examples/examples/receive_frame.rs
@@ -10,8 +10,6 @@ use esp_hal::{
     clock::{ClockControl, CpuClock},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_ieee802154::*;
 use esp_println::println;
@@ -23,29 +21,9 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     #[cfg(feature = "esp32c6")]
-    let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock160MHz).freeze();
+    let _clocks = ClockControl::configure(system.clock_control, CpuClock::Clock160MHz).freeze();
     #[cfg(feature = "esp32h2")]
-    let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock96MHz).freeze();
-
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::configure(system.clock_control, CpuClock::Clock96MHz).freeze();
 
     println!("Start");
 

--- a/esp-ieee802154-examples/examples/send_broadcast_frame.rs
+++ b/esp-ieee802154-examples/examples/send_broadcast_frame.rs
@@ -10,8 +10,7 @@ use esp_hal::{
     clock::{ClockControl, CpuClock},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Delay, Rtc,
+    Delay,
 };
 use esp_ieee802154::*;
 use esp_println::println;
@@ -27,26 +26,6 @@ fn main() -> ! {
     let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock160MHz).freeze();
     #[cfg(feature = "esp32h2")]
     let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock96MHz).freeze();
-
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp-ieee802154-examples/examples/send_frame.rs
+++ b/esp-ieee802154-examples/examples/send_frame.rs
@@ -10,8 +10,7 @@ use esp_hal::{
     clock::{ClockControl, CpuClock},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Delay, Rtc,
+    Delay,
 };
 use esp_ieee802154::*;
 use esp_println::println;
@@ -27,26 +26,6 @@ fn main() -> ! {
     let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock160MHz).freeze();
     #[cfg(feature = "esp32h2")]
     let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock96MHz).freeze();
-
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp-ieee802154-examples/examples/sniffer.rs
+++ b/esp-ieee802154-examples/examples/sniffer.rs
@@ -11,8 +11,7 @@ use esp_hal::{
     peripherals::Peripherals,
     prelude::*,
     reset::software_reset,
-    timer::TimerGroup,
-    Rtc, Uart,
+    Uart,
 };
 use esp_ieee802154::*;
 use esp_println::println;
@@ -24,29 +23,9 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     #[cfg(feature = "esp32c6")]
-    let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock160MHz).freeze();
+    let _clocks = ClockControl::configure(system.clock_control, CpuClock::Clock160MHz).freeze();
     #[cfg(feature = "esp32h2")]
-    let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock96MHz).freeze();
-
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::configure(system.clock_control, CpuClock::Clock96MHz).freeze();
 
     let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     let mut cnt = 0;

--- a/esp-ieee802154/Cargo.toml
+++ b/esp-ieee802154/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
-name = "esp-ieee802154"
-version = "0.1.0"
-edition = "2021"
+name        = "esp-ieee802154"
+version     = "0.1.0"
+edition     = "2021"
 description = "Low-level IEEE 802.15.4 driver for the ESP32-C6 and ESP32-H2"
-repository = "https://github.com/esp-rs/esp-ieee802154"
-license = "MIT OR Apache-2.0"
+repository  = "https://github.com/esp-rs/esp-ieee802154"
+license     = "MIT OR Apache-2.0"
 
 [lib]
 bench = false
-test = false
+test  = false
 
 [dependencies]
-byte = "0.2.6"
-critical-section = "1.1.1"
-esp32c6-hal = { version = "0.4.0", optional = true }
-esp32h2-hal = { version = "0.2.0", optional = true }
-heapless = "0.7.16"
-ieee802154 = "0.6.1"
-log = "0.4.18"
-vcell = "0.1.3"
+byte             = "0.2.6"
+critical-section = "1.1.2"
+esp32c6-hal      = { version = "0.5.0", optional = true }
+esp32h2-hal      = { version = "0.3.0", optional = true }
+heapless         = "0.7.16"
+ieee802154       = "0.6.1"
+log              = "0.4.20"
+vcell            = "0.1.3"
 
 [features]
 default = []


### PR DESCRIPTION
Use the latest HALs, update any other dependencies with new versions, and remove the watchdog disable boilerplate from the examples.